### PR TITLE
v2.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aperture_finance/uniswap-v3-automation-sdk",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "SDK for Aperture's Uniswap V3 automation platform",
   "author": "Aperture Finance <engineering@aperture.finance>",
   "license": "MIT",


### PR DESCRIPTION
I released 2.2.5 tag. However, the `package.json` version is 2.2.6. This PR is to align version to a new/fresh version tag.