### PR TITLE
Remove amm from getStrategyDetailRequest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aperture_finance/uniswap-v3-automation-sdk",
-  "version": "3.0.3-alpha",
+  "version": "3.0.4-alpha",
   "description": "SDK for Aperture's Uniswap V3 automation platform",
   "author": "Aperture Finance <engineering@aperture.finance>",
   "license": "MIT",

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -608,6 +608,7 @@ export const UpdateTriggerRequestSchema = PayloadSignatureSchema.extend({
 export type UpdateTriggerRequest = z.infer<typeof UpdateTriggerRequestSchema>;
 
 export const ListTriggerRequestSchema = BaseTriggerPayloadSchema.extend({
+  amm: AutomatedMarketMakerEnum,
   isLimitOrder: z
     .boolean()
     .describe(
@@ -750,10 +751,13 @@ export type GetStrategiesDetailRequest = z.infer<
   typeof GetStrategiesDetailRequestSchema
 >;
 
-export const GetStrategyDetailRequestSchema =
-  GetStrategiesDetailRequestSchema.extend({
-    strategyId: z.string().min(1).describe('The id of the strategy.'),
-  });
+export const GetStrategyDetailRequestSchema = ClientTypeSchema.extend({
+  ownerAddr: AddressSchema.describe(
+    'The owner address of position `tokenId`; must be a checksum address.',
+  ),
+  chainId: ApertureSupportedChainIdEnum,
+  strategyId: z.string().min(1).describe('The id of the strategy.'),
+});
 export type GetStrategyDetailRequest = z.infer<
   typeof GetStrategyDetailRequestSchema
 >;

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -740,24 +740,25 @@ export type HasSignedPrivateBetaAgreementResponse = z.infer<
   typeof HasSignedPrivateBetaAgreementResponseSchema
 >;
 
-export const GetStrategiesDetailRequestSchema = ClientTypeSchema.extend({
+const GetStrategyRequestBaseSchema = ClientTypeSchema.extend({
   ownerAddr: AddressSchema.describe(
-    'The owner address of position `tokenId`; must be a checksum address.',
+    'The owner address of the request strategy/strategies; must be a checksum address.',
   ),
   chainId: ApertureSupportedChainIdEnum,
-  amm: AutomatedMarketMakerEnum,
 });
+
+export const GetStrategiesDetailRequestSchema =
+  GetStrategyRequestBaseSchema.extend({
+    amm: AutomatedMarketMakerEnum,
+  });
 export type GetStrategiesDetailRequest = z.infer<
   typeof GetStrategiesDetailRequestSchema
 >;
 
-export const GetStrategyDetailRequestSchema = ClientTypeSchema.extend({
-  ownerAddr: AddressSchema.describe(
-    'The owner address of position `tokenId`; must be a checksum address.',
-  ),
-  chainId: ApertureSupportedChainIdEnum,
-  strategyId: z.string().min(1).describe('The id of the strategy.'),
-});
+export const GetStrategyDetailRequestSchema =
+  GetStrategyRequestBaseSchema.extend({
+    strategyId: z.string().min(1).describe('The id of the strategy.'),
+  });
 export type GetStrategyDetailRequest = z.infer<
   typeof GetStrategyDetailRequestSchema
 >;


### PR DESCRIPTION
The strategy id already identifies a series of rebalances on a particular AMM, so AMM doesn't need to be part of the request.