### PR TITLE
refactor getAllPositions to avoid 429 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aperture_finance/uniswap-v3-automation-sdk",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "description": "SDK for Aperture's Uniswap V3 automation platform",
   "author": "Aperture Finance <engineering@aperture.finance>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aperture_finance/uniswap-v3-automation-sdk",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "SDK for Aperture's Uniswap V3 automation platform",
   "author": "Aperture Finance <engineering@aperture.finance>",
   "license": "MIT",

--- a/src/viem/position.ts
+++ b/src/viem/position.ts
@@ -162,7 +162,7 @@ export async function getAllPositions(
   publicClient?: PublicClient,
   blockNumber?: bigint,
 ): Promise<Map<string, PositionDetails>> {
-  let positions: PositionStateArray;
+  let positions: PositionStateArray = [];
   publicClient = publicClient ?? getPublicClient(chainId);
   try {
     positions = await viem.getAllPositionsByOwner(
@@ -177,45 +177,27 @@ export async function getAllPositions(
     //   - Get the number of positions owned by the owner.
     //   - Batch fetch token ids.
     //   - Batch fetch position details using token ids.
-    const npm = getNPM(chainId, amm, publicClient);
-    const numPositions = await npm.read.balanceOf([owner], { blockNumber });
-    const tokenIds = (
-      await publicClient.multicall({
-        contracts: [...Array(Number(numPositions)).keys()].map((i) => {
-          return {
-            address: npm.address,
-            abi: npm.abi,
-            functionName: 'tokenOfOwnerByIndex',
-            args: [owner, BigInt(i)],
-            blockNumber,
-          };
-        }),
-        allowFailure: false,
-        batchSize: 2_048,
-      })
-    ).map((i) => BigInt(i ?? 0));
-
-    // Fetch position state.
-    positions = flatten(
-      await Promise.all(
-        chunk(tokenIds, 500).map((tokenIdsChunk) => {
-          try {
-            return viem.getPositions(
-              npm.address,
-              tokenIdsChunk,
-              publicClient!,
-              blockNumber,
-            );
-          } catch (error) {
-            console.warn(
-              'Failed to getPositions on tokenIdsChunk',
-              tokenIdsChunk,
-              error,
-            );
-            return [];
-          }
-        }),
-      ),
+    const numPositions = await getPositionsNumberOwnedByOwner(
+      owner,
+      chainId,
+      amm,
+      publicClient,
+      blockNumber,
+    );
+    const tokenIds = await getTokenIds(
+      owner,
+      chainId,
+      amm,
+      numPositions,
+      publicClient,
+      blockNumber,
+    );
+    positions = await getPositionsState(
+      chainId,
+      amm,
+      tokenIds,
+      publicClient,
+      blockNumber,
     );
   }
 
@@ -228,6 +210,161 @@ export async function getAllPositions(
         ] as const,
     ),
   );
+}
+
+/**
+ * Get the number of positions owned by the owner.
+ * @param owner The owner.
+ * @param chainId Chain id.
+ * @param amm Automated Market Maker.
+ * @param publicClient Viem public client.
+ * @param blockNumber Optional block number to query.
+ * @returns The number of positions owned by the owner.
+ */
+export async function getPositionsNumberOwnedByOwner(
+  owner: Address,
+  chainId: ApertureSupportedChainId,
+  amm: AutomatedMarketMakerEnum,
+  publicClient?: PublicClient,
+  blockNumber?: bigint,
+): Promise<number> {
+  publicClient = publicClient ?? getPublicClient(chainId);
+  const npm = getNPM(chainId, amm, publicClient);
+  try {
+    const numPositions: bigint = await npm.read.balanceOf([owner], {
+      blockNumber,
+    });
+    return Number(numPositions);
+  } catch (error) {
+    console.warn(`Failed to getPositionsNumber on ${amm}-${chainId}`, error);
+    return 0;
+  }
+}
+
+/**
+ * Get the token ids owned by the owner.
+ * @param owner The owner.
+ * @param chainId Chain id.
+ * @param amm Automated Market Maker.
+ * @param numPositions Positions number.
+ * @param publicClient Viem public client.
+ * @param blockNumber Optional block number to query.
+ * @param timeout Optional delay time between promises.
+ * @param batchSize Optional batch size of positions to fetch.
+ * @returns Token ids owned by the owner.
+ */
+export async function getTokenIds(
+  owner: Address,
+  chainId: ApertureSupportedChainId,
+  amm: AutomatedMarketMakerEnum,
+  numPositions: number,
+  publicClient?: PublicClient,
+  blockNumber?: bigint,
+  timeout?: number,
+  batchSize?: number,
+): Promise<bigint[]> {
+  publicClient = publicClient ?? getPublicClient(chainId);
+  const npm = getNPM(chainId, amm, publicClient);
+  batchSize = batchSize ?? 10_000;
+  timeout = timeout ?? 5_000;
+  let tokenIds: bigint[] = [];
+  const tokenIdsArray = [...Array(numPositions).keys()];
+  for (let i = 0; i < numPositions; i += batchSize) {
+    const currentBatch = tokenIdsArray.slice(i, i + batchSize);
+    let currentTokenIds: bigint[] = [];
+    try {
+      currentTokenIds = (
+        await publicClient.multicall({
+          contracts: currentBatch.map((i) => {
+            return {
+              address: npm.address,
+              abi: npm.abi,
+              functionName: 'tokenOfOwnerByIndex',
+              args: [owner, BigInt(i)],
+              blockNumber,
+            };
+          }),
+          allowFailure: false,
+          batchSize: 102_400,
+        })
+      ).map((i) => BigInt(i ?? 0));
+      tokenIds = tokenIds.concat(currentTokenIds);
+    } catch (error) {
+      console.warn(
+        `Failed to getTokenIds on ${amm}-${chainId} from ${i} to ${i + batchSize}`,
+        error,
+      );
+    }
+
+    if (currentTokenIds.length && i + batchSize < numPositions) {
+      await new Promise((resolve) => setTimeout(resolve, timeout));
+    }
+  }
+
+  return tokenIds;
+}
+
+/**
+ * Get positions state
+ * @param chainId Chain id.
+ * @param amm Automated Market Maker.
+ * @param tokenIds Token ids owned by the owner.
+ * @param publicClient Viem public client.
+ * @param blockNumber Optional block number to query.
+ * @param timeout Optional delay time between promises.
+ * @param batchSize Optional batch size to fetch.
+ * @returns Position state array.
+ */
+export async function getPositionsState(
+  chainId: ApertureSupportedChainId,
+  amm: AutomatedMarketMakerEnum,
+  tokenIds: bigint[],
+  publicClient?: PublicClient,
+  blockNumber?: bigint,
+  timeout?: number,
+  batchSize?: number,
+): Promise<PositionStateArray> {
+  publicClient = publicClient ?? getPublicClient(chainId);
+  batchSize = batchSize ?? 10_000;
+  timeout = timeout ?? 5_000;
+  let positions: PositionStateArray = [];
+  const npm = getNPM(chainId, amm, publicClient);
+  if (tokenIds.length) {
+    for (let i = 0; i < tokenIds.length; i += batchSize) {
+      let currentPositions: PositionStateArray = [];
+      const currentBatch = tokenIds.slice(i, i + batchSize);
+
+      // Fetch position state.
+      currentPositions = flatten(
+        await Promise.all(
+          chunk(currentBatch, 500).map((tokenIdsChunk) => {
+            try {
+              return viem.getPositions(
+                npm.address,
+                tokenIdsChunk,
+                publicClient!,
+                blockNumber,
+              );
+            } catch (error) {
+              console.warn(
+                `Failed to getPositions on ${amm}-${chainId}`,
+                tokenIdsChunk,
+                error,
+              );
+              return [];
+            }
+          }),
+        ),
+      );
+      positions = positions.concat(currentPositions);
+
+      if (currentPositions.length && i + batchSize < tokenIds.length) {
+        await new Promise((resolve) => setTimeout(resolve, timeout));
+      }
+    }
+  }
+
+  return positions;
 }
 
 /**

--- a/src/viem/position.ts
+++ b/src/viem/position.ts
@@ -177,7 +177,7 @@ export async function getAllPositions(
     //   - Get the number of positions owned by the owner.
     //   - Batch fetch token ids.
     //   - Batch fetch position details using token ids.
-    const numPositions = await getPositionsNumberOwnedByOwner(
+    const numPositions = await getNumberOfPositionsOwnedByOwner(
       owner,
       chainId,
       amm,
@@ -221,7 +221,7 @@ export async function getAllPositions(
  * @param blockNumber Optional block number to query.
  * @returns The number of positions owned by the owner.
  */
-export async function getPositionsNumberOwnedByOwner(
+export async function getNumberOfPositionsOwnedByOwner(
   owner: Address,
   chainId: ApertureSupportedChainId,
   amm: AutomatedMarketMakerEnum,

--- a/src/viem/public_client.ts
+++ b/src/viem/public_client.ts
@@ -1,22 +1,24 @@
 import { ApertureSupportedChainId, getChainInfo } from '@/index';
 import { providers } from 'ethers';
-import { PublicClient, createPublicClient, http } from 'viem';
 import type { Transport } from 'viem';
+import { PublicClient, createPublicClient, http } from 'viem';
 
 /**
  * Creates a Viem public client for the specified chain id.
  * @param chainId chain id must be supported by Aperture's UniV3 Automation platform.
+ * @param rpc_url rpc_url.
  * @returns A multicall-enabled public client.
  */
 export function getPublicClient(
   chainId: ApertureSupportedChainId,
+  rpc_url?: string,
 ): PublicClient {
   return createPublicClient({
     batch: {
       multicall: true,
     },
     chain: getChainInfo(chainId).chain,
-    transport: http(getChainInfo(chainId).rpc_url),
+    transport: http(rpc_url ?? getChainInfo(chainId).rpc_url),
   });
 }
 

--- a/test/hardhat/hardhat.test.ts
+++ b/test/hardhat/hardhat.test.ts
@@ -869,7 +869,7 @@ describe('Position util tests', function () {
   });
 
   it('Test getAllPositions with large balances', async function () {
-    const publicClient = getPublicClient(1);
+    const publicClient = getPublicClient(1, 'https://ethereum.publicnode.com');
     // An address with 7000+ positions on mainnet.
     const address = '0x6dD91BdaB368282dc4Ea4f4beFc831b78a7C38C0';
     const positionDetails = await getAllPositions(


### PR DESCRIPTION
1. Refactor
    1.  Batch fetch token ids.
    2. Batch fetch position details.

2. Update `publicClient.multicall({batchSize})` from 2_048 to 102_400 for less eth_call

Note:
Test pass on Arbitrum - 0x732468B15E9DD854B86D10a0fb8E83F6283fE7a2 up to 9000+ positions.
Test pass on Ethereum - 0x6dD91BdaB368282dc4Ea4f4beFc831b78a7C38C0 up to 7000+ positions.