### PR TITLE
catch fee calc error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aperture_finance/uniswap-v3-automation-sdk",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "description": "SDK for Aperture's Uniswap V3 automation platform",
   "author": "Aperture Finance <engineering@aperture.finance>",
   "license": "MIT",

--- a/src/viem/aggregator/optimalRebalanceV2.ts
+++ b/src/viem/aggregator/optimalRebalanceV2.ts
@@ -125,8 +125,12 @@ export async function optimalRebalanceV2(
 
   let feeBips = 0n,
     feeUSD = '0';
-  if (feesOn) {
-    ({ feeBips, feeUSD } = await calcFeeBips());
+  try {
+    if (feesOn) {
+      ({ feeBips, feeUSD } = await calcFeeBips());
+    }
+  } catch (e) {
+    console.warn('Error calculating fee', e);
   }
 
   const { receive0, receive1, poolAmountIn, zeroForOne } =

--- a/src/viem/aggregator/optimalRebalanceV2.ts
+++ b/src/viem/aggregator/optimalRebalanceV2.ts
@@ -131,6 +131,7 @@ export async function optimalRebalanceV2(
     }
   } catch (e) {
     console.warn('Error calculating fee', e);
+    // TODO: logging to datadog
   }
 
   const { receive0, receive1, poolAmountIn, zeroForOne } =


### PR DESCRIPTION
Sometime failed to calc fee, says divided by zero, so catch the error first


feeBips: BigInt(feeUSD.div(positionUSD).mul(feeCoefficient).toFixed(0)),


![image](https://github.com/Aperture-Finance/uniswap-v3-automation-sdk/assets/149023997/df20ad63-994f-4a80-9bf6-f071338c23e9)
