### PR TITLE
remove 1inch from all_solvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aperture_finance/uniswap-v3-automation-sdk",
-  "version": "3.10.9",
+  "version": "3.10.10",
   "description": "SDK for Aperture's CLMM automation platform",
   "author": "Aperture Finance <engineering@aperture.finance>",
   "license": "MIT",

--- a/src/viem/solver/types.ts
+++ b/src/viem/solver/types.ts
@@ -45,7 +45,7 @@ export const ALL_SOLVERS = [
   E_Solver.SamePool,
   E_Solver.PH,
   E_Solver.OKX,
-  E_Solver.OneInch,
+  // E_Solver.OneInch, // no longer paying for enterprise plan
 ]; // order matters
 
 export type SwapPath = {


### PR DESCRIPTION
all_solvers are default for V2 transactions (e.g. optimalRebalanceV2, optimalMintV2, etc.)