### PR TITLE
Delete subgraph urls from chain info.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aperture_finance/uniswap-v3-automation-sdk",
-  "version": "3.13.6",
+  "version": "3.14.0",
   "description": "SDK for Aperture's CLMM automation platform",
   "author": "Aperture Finance <engineering@aperture.finance>",
   "license": "MIT",
@@ -40,10 +40,10 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@0xsequence/multicall": "^1.10.9",
+    "@0xsequence/multicall": "^1.10.15",
     "@aperture_finance/uniswap-v3-sdk": "3.11.0-APTR.2",
     "aperture-lens": "^2.0.2",
-    "axios": "^1.7.3",
+    "axios": "^1.7.9",
     "big.js": "^6.2.1",
     "bottleneck": "^2.19.5",
     "eip1167": "^0.1.1",
@@ -83,12 +83,12 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "hardhat": "^2.22.7",
+    "hardhat": "^2.22.17",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
     "ts-node": "10.9.2",
     "tsc-alias": "^1.8.10",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "5.4.5"
+    "typescript": "5.7.2"
   }
 }

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -64,9 +64,7 @@ export interface AmmInfo {
   // Aperture's Automan contract address.
   apertureAutoman: Address;
   apertureAutomanV3: Address;
-  // The subgraph URL for the AMM.
-  // For Uniswap, refer to https://docs.uniswap.org/api/subgraph/overview.
-  // For PancakeSwap, refer to https://github.com/pancakeswap/pancake-subgraph.
+  // The subgraph URL for the AMM. Currently unset for all AMMs as there are no public, free endpoints.
   subgraph_url?: string;
 }
 
@@ -111,8 +109,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x00000070ee937917c1d9bD91729ce1Dd9A77d8e3',
         ),
-        subgraph_url:
-          'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3',
       },
       [AutomatedMarketMakerEnum.enum.PANCAKESWAP_V3]: {
         factory: getAddress('0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865'),
@@ -130,8 +126,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x00000076a5FEfF94a54834fe1b2803a6Da672e03',
         ),
-        subgraph_url:
-          'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
       },
     },
     wrappedNativeCurrency: new Token(
@@ -167,8 +161,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x00000070ee937917c1d9bD91729ce1Dd9A77d8e3',
         ),
-        subgraph_url:
-          'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-arbitrum-one',
       },
     },
     wrappedNativeCurrency: new Token(
@@ -204,8 +196,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x00000070ee937917c1d9bD91729ce1Dd9A77d8e3',
         ),
-        subgraph_url:
-          'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-polygon',
       },
     },
     wrappedNativeCurrency: new Token(
@@ -241,8 +231,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x00000070ee937917c1d9bD91729ce1Dd9A77d8e3',
         ),
-        subgraph_url:
-          'https://api.thegraph.com/subgraphs/name/ianlapham/optimism-post-regenesis',
       },
       [AutomatedMarketMakerEnum.enum.SLIPSTREAM]: {
         // https://velodrome.finance/security#contracts
@@ -297,8 +285,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x000000E2F3Dd82130669b730Bdf170D12DF35233',
         ),
-        subgraph_url:
-          'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-bsc',
       },
       [AutomatedMarketMakerEnum.enum.PANCAKESWAP_V3]: {
         factory: getAddress('0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865'),
@@ -316,8 +302,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x00000076a5FEfF94a54834fe1b2803a6Da672e03',
         ),
-        subgraph_url:
-          'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc',
       },
     },
     wrappedNativeCurrency: new Token(
@@ -353,8 +337,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x000000C51119E2bDE2419C5e6fD273a81B79A8E3',
         ),
-        subgraph_url:
-          'https://api.studio.thegraph.com/query/48211/uniswap-v3-base/version/latest',
       },
       [AutomatedMarketMakerEnum.enum.SLIPSTREAM]: {
         // https://aerodrome.finance/security#contracts
@@ -409,8 +391,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x00000075Cd3dAd5805699d0E1C5734e27B3264e3',
         ),
-        subgraph_url:
-          'https://api.thegraph.com/subgraphs/name/lynnshaoyu/uniswap-v3-avax',
       },
     },
     wrappedNativeCurrency: new Token(
@@ -446,8 +426,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x000000bf0E089A0991baB3CD0E111213c71a5aD3',
         ),
-        subgraph_url:
-          'https://api.goldsky.com/api/public/project_clnz7akg41cv72ntv0uhyd3ai/subgraphs/aperture-manta-pacific/uniswap-v3/gn',
       },
     },
     wrappedNativeCurrency: new Token(
@@ -484,8 +462,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x0000000000000000000000000000000000000000',
         ),
-        subgraph_url:
-          'https://d3lcl3uht06cq4.cloudfront.net/subgraphs/name/aperture/uniswap-v3',
       },
     },
     wrappedNativeCurrency: new Token(
@@ -521,8 +497,6 @@ const CHAIN_ID_TO_INFO: {
         apertureAutomanV3: getAddress(
           '0x00000027bC53f021F3564180f347425eDAA20883',
         ),
-        subgraph_url:
-          'https://api.goldsky.com/api/public/project_clnz7akg41cv72ntv0uhyd3ai/subgraphs/aperture-scroll/uniswap-v3/gn',
       },
     },
     wrappedNativeCurrency: new Token(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,55 +2,55 @@
 # yarn lockfile v1
 
 
-"@0xsequence/abi@1.10.9":
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/@0xsequence/abi/-/abi-1.10.9.tgz#8bdbb68ef7d1284f0da5b4e6b44cd0dacc8605a4"
-  integrity sha512-HSGOsJv8ORRVaLbrAsfOqJNbnKRtpVSReX1ltwZ/W96312wG6FT6DAR+d2htQDO+M+eN89kM9tCwgEVONOl01g==
+"@0xsequence/abi@1.10.15":
+  version "1.10.15"
+  resolved "https://registry.yarnpkg.com/@0xsequence/abi/-/abi-1.10.15.tgz#7446f9eb96ec68081f1539e3de30e5a5c805e460"
+  integrity sha512-nuh68P8tRDzIMIH7mnGX1Eab0jsYVGhZa7IlNIs8CfTnGoanxLS+MGk5ioZBa6+slzxb9VP8mnQ5QhAWeFySeg==
 
-"@0xsequence/core@1.10.9":
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/@0xsequence/core/-/core-1.10.9.tgz#3505956f5ed8e4b806bb0d1b59c98ff6c6ebd9f5"
-  integrity sha512-KvWmP2+RZBDmj5olIJYaWzBhislzLflare+dlHBAP1uI9ShHmIJc75SQEh955+g1HfqPClipqNxZKvTqLESOvQ==
+"@0xsequence/core@1.10.15":
+  version "1.10.15"
+  resolved "https://registry.yarnpkg.com/@0xsequence/core/-/core-1.10.15.tgz#3dfb4c7a3d3f027b04213d94a8f29c84df51c04f"
+  integrity sha512-wrE5soJSqrhhm7pC+NxckLR0lJSOnsHPLKdDqWeTRmyuhtZ4e0DsrcoeoD40I/3Bd77tdZ1GGbq00CryV7JfFw==
   dependencies:
-    "@0xsequence/abi" "1.10.9"
+    "@0xsequence/abi" "1.10.15"
 
-"@0xsequence/indexer@1.10.9":
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/@0xsequence/indexer/-/indexer-1.10.9.tgz#aa117c8825ffda2c43210ee140e3296cfa05385b"
-  integrity sha512-WNMck+fONiwXGrObc/4igbj9/bKALqyemIViSkMgfKjwURzfzVx/neCyvHf9bIYWFKgJnHOY+n+kTm5Tx2dZwQ==
+"@0xsequence/indexer@1.10.15":
+  version "1.10.15"
+  resolved "https://registry.yarnpkg.com/@0xsequence/indexer/-/indexer-1.10.15.tgz#bd632aebe8429d5bc74ceefe30ebd0230dde2cdf"
+  integrity sha512-bc2gAIEplMcmWJMwLuXZZ0wifoxuV/zHyWzEdbQ5+9ruIXArxyoG0Ue9fMEzKWHfsAWyBKBJCCFbr4XJEQ5YjA==
 
-"@0xsequence/multicall@^1.10.9":
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/@0xsequence/multicall/-/multicall-1.10.9.tgz#4abca7d2ee7e77e15ac00a0228561ccfa6ea8dd8"
-  integrity sha512-4FgmpEhOkkGmS6DQDchs/MgmaIUI7wNeYYIT1k2bqvE3bBDVkPuaT/yiaSRKXkdK5qxLkAagSF6arYepeRzaQA==
+"@0xsequence/multicall@^1.10.15":
+  version "1.10.15"
+  resolved "https://registry.yarnpkg.com/@0xsequence/multicall/-/multicall-1.10.15.tgz#15fdae9ada074ca672dd9de4ec8cb8107969ef1f"
+  integrity sha512-yFTMDZR9tUvm3lefYyuxhohtx6mFzdpmn+qDFk9Bjo5TeEu0SGJLjdd6U2AK3rDIcPPw7rl7VvBXLweNJOMjfw==
   dependencies:
-    "@0xsequence/abi" "1.10.9"
-    "@0xsequence/network" "1.10.9"
-    "@0xsequence/utils" "1.10.9"
+    "@0xsequence/abi" "1.10.15"
+    "@0xsequence/network" "1.10.15"
+    "@0xsequence/utils" "1.10.15"
 
-"@0xsequence/network@1.10.9":
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/@0xsequence/network/-/network-1.10.9.tgz#2b2b7bca54a4f21adcef58b0f49bf916d64ef4aa"
-  integrity sha512-gXtSH1Az8oVOG4NMcFKoBBKg5A56iGwIFn5POFfkWiZYsrRM6qE97SrOkzSCH6W6bG7I8FOpuCcHVoBFE8WXYg==
+"@0xsequence/network@1.10.15":
+  version "1.10.15"
+  resolved "https://registry.yarnpkg.com/@0xsequence/network/-/network-1.10.15.tgz#40d24dd2f72e4c1b0045da80a0b873baa8bfd48c"
+  integrity sha512-wHp8RGqFrncuoIh0ityO/jUobliargQ7SWlvZCf8Ez0T7uiXDEDokrFSN2F9FIl6i5a5NmcEpXhfhwS/L0pN2w==
   dependencies:
-    "@0xsequence/core" "1.10.9"
-    "@0xsequence/indexer" "1.10.9"
-    "@0xsequence/relayer" "1.10.9"
-    "@0xsequence/utils" "1.10.9"
+    "@0xsequence/core" "1.10.15"
+    "@0xsequence/indexer" "1.10.15"
+    "@0xsequence/relayer" "1.10.15"
+    "@0xsequence/utils" "1.10.15"
 
-"@0xsequence/relayer@1.10.9":
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/@0xsequence/relayer/-/relayer-1.10.9.tgz#d1c9bd64bf0aa8f27f53afbeda2e55545ced3daf"
-  integrity sha512-Yqlkad1FL3ZBfQSgiEhW4LsNXOX8CC0OkogXhMjVxLZeiJjs2gLZ6NRiuRN51I5VSCx+w6cWY/e29sOUHAFdpQ==
+"@0xsequence/relayer@1.10.15":
+  version "1.10.15"
+  resolved "https://registry.yarnpkg.com/@0xsequence/relayer/-/relayer-1.10.15.tgz#0d6cb723893f506c1eeb8c10401454880fe72457"
+  integrity sha512-QpNAzRjqCl9xJdXzErQA0kmv2jzEXPfVlPwutbgmrCEIj+rHdw3M+kiG0MWBnOqxoSEA98oJnxXmpBL5mkCA6g==
   dependencies:
-    "@0xsequence/abi" "1.10.9"
-    "@0xsequence/core" "1.10.9"
-    "@0xsequence/utils" "1.10.9"
+    "@0xsequence/abi" "1.10.15"
+    "@0xsequence/core" "1.10.15"
+    "@0xsequence/utils" "1.10.15"
 
-"@0xsequence/utils@1.10.9":
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/@0xsequence/utils/-/utils-1.10.9.tgz#9f573dbcc25f36c6d86977a99e3eb71440ae2584"
-  integrity sha512-yrznannQgdWilp1KNtiN/L4sN7Wa14UmwKkZwxQBQ1x1Sk4PMCXCr6qYVCrFi84FacMnGtI2iycbh2wjZEixLA==
+"@0xsequence/utils@1.10.15":
+  version "1.10.15"
+  resolved "https://registry.yarnpkg.com/@0xsequence/utils/-/utils-1.10.15.tgz#b98589d2b30d0246d9c9256779e39c4e3a6dcde5"
+  integrity sha512-LIrQS5J+3MOER+i7ajX7fiT6ga3QoDf8wsi5KY/2eFZS39sbCXGzg1ORxjtee++c/S/h4nuRYX1IRuseGYJWPw==
   dependencies:
     js-base64 "^3.7.2"
 
@@ -2701,53 +2701,53 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nomicfoundation/edr-darwin-arm64@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.5.0.tgz#08b7302c7ce00e3c4dc43e7cfc9065997463c470"
-  integrity sha512-G6OX/PESdfU4ZOyJ4MDh4eevW0wt2mduuxA+thXtTcStOiQTtPuV205h4kLOR5wRB1Zz6Zy0LedTMax7TzOtGw==
+"@nomicfoundation/edr-darwin-arm64@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.6.5.tgz#37a31565d7ef42bed9028ac44aed82144de30bd1"
+  integrity sha512-A9zCCbbNxBpLgjS1kEJSpqxIvGGAX4cYbpDYCU2f3jVqOwaZ/NU761y1SvuCRVpOwhoCXqByN9b7HPpHi0L4hw==
 
-"@nomicfoundation/edr-darwin-x64@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.5.0.tgz#4a30a8584721bffd1ad6d7cc7fb70f2b2034e3b5"
-  integrity sha512-fI7uHfHqPtdPZjkFUTpotc/F5gGv41ws+jSZy9+2AR9RDMOAIXMEArOx9rGLBcevWu8SFnyH/l/77kG/5FXbDw==
+"@nomicfoundation/edr-darwin-x64@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.6.5.tgz#3252f6e86397af460b7a480bfe1b889464d75b89"
+  integrity sha512-x3zBY/v3R0modR5CzlL6qMfFMdgwd6oHrWpTkuuXnPFOX8SU31qq87/230f4szM+ukGK8Hi+mNq7Ro2VF4Fj+w==
 
-"@nomicfoundation/edr-linux-arm64-gnu@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.5.0.tgz#f4a0e9a5ac8157dc4e241f751c8e8b09f446aa8d"
-  integrity sha512-eMC3sWPkBZILg2/YB4Xv6IR0nggCLt5hS8K8jjHeGEeUs9pf8poBF2Oy+G4lSu0YLLjexGzHypz9/P+pIuxZHw==
+"@nomicfoundation/edr-linux-arm64-gnu@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.6.5.tgz#e7dc2934920b6cfabeb5ee7a5e26c8fb0d4964ac"
+  integrity sha512-HGpB8f1h8ogqPHTyUpyPRKZxUk2lu061g97dOQ/W4CxevI0s/qiw5DB3U3smLvSnBHKOzYS1jkxlMeGN01ky7A==
 
-"@nomicfoundation/edr-linux-arm64-musl@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.5.0.tgz#34e240a02ebb8d6e0e262642058370f24d555386"
-  integrity sha512-yPK0tKjYRxe5ktggFr8aBHH0DCI9uafuaD8QuzyrQAfSf/m/ebTdgthROdbYp6eRk5mJyfAQT/45fM3tnlYsWw==
+"@nomicfoundation/edr-linux-arm64-musl@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.6.5.tgz#00459cd53e9fb7bd5b7e32128b508a6e89079d89"
+  integrity sha512-ESvJM5Y9XC03fZg9KaQg3Hl+mbx7dsSkTIAndoJS7X2SyakpL9KZpOSYrDk135o8s9P9lYJdPOyiq+Sh+XoCbQ==
 
-"@nomicfoundation/edr-linux-x64-gnu@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.5.0.tgz#c118f26567eba994133c7fda11a022dee46c5e13"
-  integrity sha512-Hds8CRYi4DEyuErjcwUNSvNpMzmOYUihW4qYCoKgSBUVS5saX1PyPYvFYuYpeU5J8/T2iMk6yAPVLCxtKbgnKg==
+"@nomicfoundation/edr-linux-x64-gnu@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.6.5.tgz#5c9e4e2655caba48e0196977cba395bbde6fe97d"
+  integrity sha512-HCM1usyAR1Ew6RYf5AkMYGvHBy64cPA5NMbaeY72r0mpKaH3txiMyydcHibByOGdQ8iFLWpyUdpl1egotw+Tgg==
 
-"@nomicfoundation/edr-linux-x64-musl@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.5.0.tgz#b437a652ead59186b566fc2c7a45278018d85806"
-  integrity sha512-1hXMDSzdyh5ojwO3ZSRbt7t5KKYycGUlFdC3lgJRZ7gStB8xjb7RA3hZn2csn9OydS950Ne4nh+puNq91iXApw==
+"@nomicfoundation/edr-linux-x64-musl@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.6.5.tgz#9c220751b66452dc43a365f380e1e236a0a8c5a9"
+  integrity sha512-nB2uFRyczhAvWUH7NjCsIO6rHnQrof3xcCe6Mpmnzfl2PYcGyxN7iO4ZMmRcQS7R1Y670VH6+8ZBiRn8k43m7A==
 
-"@nomicfoundation/edr-win32-x64-msvc@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.5.0.tgz#0dd0eb9c0d6c2f47403393b9712dd8577bd06041"
-  integrity sha512-CFagD423400xXkRmACIR13FoocN48qi4ogRnuFQIvBDtEE3aMEajfFj4bycmQQDqnqChsZy/jwD4OxbX6oaNJw==
+"@nomicfoundation/edr-win32-x64-msvc@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.6.5.tgz#90d3ac2a6a8a687522bda5ff2e92dd97e68126ea"
+  integrity sha512-B9QD/4DSSCFtWicO8A3BrsnitO1FPv7axB62wq5Q+qeJ50yJlTmyeGY3cw62gWItdvy2mh3fRM6L1LpnHiB77A==
 
-"@nomicfoundation/edr@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr/-/edr-0.5.0.tgz#febcce36898ae3e01f04f2013a24b8bec0c2ca24"
-  integrity sha512-nAUyjGhxntXje/1AkDX9POfH+pqUxdi4XHzIhaf/dJYs7fgAFxL3STBK1OYcA3LR7vtiylLHMz7wxjqLzlLGKg==
+"@nomicfoundation/edr@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr/-/edr-0.6.5.tgz#b3b1ebcdd0148cfe67cca128e7ebe8092e200359"
+  integrity sha512-tAqMslLP+/2b2sZP4qe9AuGxG3OkQ5gGgHE4isUuq6dUVjwCRPFhAOhpdFl+OjY5P3yEv3hmq9HjUGRa2VNjng==
   dependencies:
-    "@nomicfoundation/edr-darwin-arm64" "0.5.0"
-    "@nomicfoundation/edr-darwin-x64" "0.5.0"
-    "@nomicfoundation/edr-linux-arm64-gnu" "0.5.0"
-    "@nomicfoundation/edr-linux-arm64-musl" "0.5.0"
-    "@nomicfoundation/edr-linux-x64-gnu" "0.5.0"
-    "@nomicfoundation/edr-linux-x64-musl" "0.5.0"
-    "@nomicfoundation/edr-win32-x64-msvc" "0.5.0"
+    "@nomicfoundation/edr-darwin-arm64" "0.6.5"
+    "@nomicfoundation/edr-darwin-x64" "0.6.5"
+    "@nomicfoundation/edr-linux-arm64-gnu" "0.6.5"
+    "@nomicfoundation/edr-linux-arm64-musl" "0.6.5"
+    "@nomicfoundation/edr-linux-x64-gnu" "0.6.5"
+    "@nomicfoundation/edr-linux-x64-musl" "0.6.5"
+    "@nomicfoundation/edr-win32-x64-msvc" "0.6.5"
 
 "@nomicfoundation/ethereumjs-common@4.0.4":
   version "4.0.4"
@@ -3925,10 +3925,10 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
-  integrity sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==
+axios@^1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
+  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -4441,7 +4441,7 @@ check-error@^1.0.2, check-error@^1.0.3:
   dependencies:
     get-func-name "^2.0.2"
 
-chokidar@3.5.3, chokidar@^3.4.0, chokidar@^3.5.3:
+chokidar@3.5.3, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -4455,6 +4455,13 @@ chokidar@3.5.3, chokidar@^3.4.0, chokidar@^3.5.3:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+chokidar@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
+  dependencies:
+    readdirp "^4.0.1"
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -5359,6 +5366,11 @@ fbjs@^3.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^1.0.35"
 
+fdir@^6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.2.tgz#ddaa7ce1831b161bc3657bb99cb36e1622702689"
+  integrity sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==
+
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -5387,13 +5399,6 @@ find-up@5.0.0, find-up@^5.0.0:
   dependencies:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
-
-find-up@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  integrity sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
-  dependencies:
-    locate-path "^2.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -5667,14 +5672,14 @@ hardhat-watcher@^2.1.1:
   dependencies:
     chokidar "^3.5.3"
 
-hardhat@^2.22.7:
-  version "2.22.7"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.22.7.tgz#3de0ce5074063cf468876c5e62f84c66d2408e8e"
-  integrity sha512-nrXQAl+qUr75TsCLDo8P41YXLc+5U7qQMMCIrbbmy1/uQaVPncdjDrD5BR0CENvHRj7EBqO+JkofpozXoIfJKg==
+hardhat@^2.22.17:
+  version "2.22.17"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.22.17.tgz#96036bbe6bad8eb6a6b65c54dc5fbc1324541612"
+  integrity sha512-tDlI475ccz4d/dajnADUTRc1OJ3H8fpP9sWhXhBPpYsQOg8JHq5xrDimo53UhWPl7KJmAeDCm1bFG74xvpGRpg==
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@metamask/eth-sig-util" "^4.0.0"
-    "@nomicfoundation/edr" "^0.5.0"
+    "@nomicfoundation/edr" "^0.6.5"
     "@nomicfoundation/ethereumjs-common" "4.0.4"
     "@nomicfoundation/ethereumjs-tx" "5.0.4"
     "@nomicfoundation/ethereumjs-util" "9.0.4"
@@ -5686,31 +5691,32 @@ hardhat@^2.22.7:
     aggregate-error "^3.0.0"
     ansi-escapes "^4.3.0"
     boxen "^5.1.2"
-    chalk "^2.4.2"
-    chokidar "^3.4.0"
+    chokidar "^4.0.0"
     ci-info "^2.0.0"
     debug "^4.1.1"
     enquirer "^2.3.0"
     env-paths "^2.2.0"
     ethereum-cryptography "^1.0.3"
     ethereumjs-abi "^0.6.8"
-    find-up "^2.1.0"
+    find-up "^5.0.0"
     fp-ts "1.19.3"
     fs-extra "^7.0.1"
-    glob "7.2.0"
     immutable "^4.0.0-rc.12"
     io-ts "1.10.4"
+    json-stream-stringify "^3.1.4"
     keccak "^3.0.2"
     lodash "^4.17.11"
     mnemonist "^0.38.0"
     mocha "^10.0.0"
     p-map "^4.0.0"
+    picocolors "^1.1.0"
     raw-body "^2.4.1"
     resolve "1.17.0"
     semver "^6.3.0"
     solc "0.8.26"
     source-map-support "^0.5.13"
     stacktrace-parser "^0.1.10"
+    tinyglobby "^0.2.6"
     tsort "0.0.1"
     undici "^5.14.0"
     uuid "^8.3.2"
@@ -6593,6 +6599,11 @@ json-stable-stringify@^1.0.1, json-stable-stringify@^1.1.1:
     jsonify "^0.0.1"
     object-keys "^1.1.1"
 
+json-stream-stringify@^3.1.4:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz#ebe32193876fb99d4ec9f612389a8d8e2b5d54d4"
+  integrity sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==
+
 json-to-pretty-yaml@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz#f4cd0bd0a5e8fe1df25aaf5ba118b099fd992d5b"
@@ -6670,14 +6681,6 @@ listr2@^4.0.5:
     rxjs "^7.5.5"
     through "^2.3.8"
     wrap-ansi "^7.0.0"
-
-locate-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  integrity sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==
-  dependencies:
-    p-locate "^2.0.0"
-    path-exists "^3.0.0"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -7157,26 +7160,12 @@ p-limit@3.1.0, p-limit@^3.0.2, p-limit@^3.1.0:
   dependencies:
     yocto-queue "^0.1.0"
 
-p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
-  dependencies:
-    p-try "^1.0.0"
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
-
-p-locate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  integrity sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==
-  dependencies:
-    p-limit "^1.1.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -7198,11 +7187,6 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
-
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -7258,11 +7242,6 @@ path-case@^3.0.4:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
-
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -7322,10 +7301,20 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picocolors@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
 pirates@^4.0.4:
   version "4.0.6"
@@ -7459,6 +7448,11 @@ readable-stream@^3.4.0, readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readdirp@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.0.2.tgz#388fccb8b75665da3abffe2d8f8ed59fe74c230a"
+  integrity sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -8048,6 +8042,14 @@ tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+tinyglobby@^0.2.6:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.10.tgz#e712cf2dc9b95a1f5c5bbd159720e15833977a0f"
+  integrity sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==
+  dependencies:
+    fdir "^6.4.2"
+    picomatch "^4.0.2"
+
 title-case@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/title-case/-/title-case-3.0.3.tgz#bc689b46f02e411f1d1e1d081f7c3deca0489982"
@@ -8206,10 +8208,10 @@ type-fest@^0.7.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
-typescript@5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 ua-parser-js@^1.0.35:
   version "1.0.37"


### PR DESCRIPTION
Delete AMM subgraph urls from chain info because "thegraph.com" free endpoints were turned down, and our own Manta Pacific and Scroll subgraphs have been pruned to only support routing.